### PR TITLE
Change order of commit -m "Message"

### DIFF
--- a/bin/git-kommit
+++ b/bin/git-kommit
@@ -96,7 +96,7 @@ if [[ -f $msg ]]; then
         wrap_at=$KOMMIT_WRAP_AT
     fi
     out=$(fold -w $wrap_at -s "${msg}" | sed "s/^/    /")
-    echo -e "\n\n$out\n\n" | cat - "${1}" > tmp_msg &&
+    echo -e "\n\n$out\n\n" | cat "${1}" - > tmp_msg &&
         mv tmp_msg "${1}" &&
         rm -f "${msg}"
 fi


### PR DESCRIPTION
Move the the commit message set with git commit -m "Message" to the top
of the kommit message instead of the bottom.

Currently if I have the following kommit-message file:

```
- changed line one
- changed line two
```

And run git commit -m "Updated two lines"

The final commit message looks like this:

```


    - changed line one
    - changed line two


Updated two lines
```

This pull request moves the command line commit message to the top.
